### PR TITLE
Trim UUID for order status

### DIFF
--- a/sources/submit.php
+++ b/sources/submit.php
@@ -29,9 +29,9 @@ if (isset($_POST['email']) && isset($_POST['custom']) && isset($_POST['project']
     }
     session_destroy();
 } else if (isset($_POST['uuid'])) {
-    $uuid = $_POST['uuid'];
+    $uuid = trim($_POST['uuid']);
 } else if (isset($_GET['uuid'])){
-    $uuid = $_GET['uuid'];
+    $uuid = trim($_GET['uuid']);
 } else {
     $url = "https://teamrecup.fr/stock.php";
     header("Location: ".$url);


### PR DESCRIPTION
Currently, pasting a UUID with a whitespace before or after the UUID itself results in a silent failure, redirecting the user to the `stock` page.

This PR simply trims the input to make it work when people paste it with spaces for examples, from emails.